### PR TITLE
データベースカラム追加

### DIFF
--- a/db/migrate/20191208035046_add_details_to_items.rb
+++ b/db/migrate/20191208035046_add_details_to_items.rb
@@ -1,0 +1,6 @@
+class AddDetailsToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :items, :buyer_id, :integer
+    add_column :items, :seller_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_30_093249) do
+ActiveRecord::Schema.define(version: 2019_12_08_035046) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "code", null: false
@@ -64,17 +64,20 @@ ActiveRecord::Schema.define(version: 2019_11_30_093249) do
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.text "description", null: false
-    t.integer "price", null: false
-    t.string "size", null: false
-    t.integer "category_id", null: false
-    t.integer "brand_id", null: false
-    t.string "status", null: false
-    t.string "ship_method", null: false
-    t.string "ship_person", null: false
-    t.string "ship_area", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer "price"
+    t.string "size", default: ""
+    t.integer "category_id"
+    t.integer "brand_id"
+    t.string "status", default: ""
+    t.string "ship_method", default: ""
+    t.string "ship_person", default: ""
+    t.string "ship_area", default: ""
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string "ship_days"
+    t.string "ship_fee", limit: 11
+    t.integer "buyer_id"
+    t.integer "seller_id"
   end
 
   create_table "sellers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
# What
アイテムテーブルに出品者であるseller_idと、購入者であるbuyer_idカラムを追加

# Why
購入者と出品者を区別することで、商品とに紐づけしやすくするため